### PR TITLE
fix duplicated pokemon

### DIFF
--- a/poKeAngular/src/app/pages/favorites/favorites.component.ts
+++ b/poKeAngular/src/app/pages/favorites/favorites.component.ts
@@ -100,6 +100,37 @@ export class FavoritesComponent implements OnInit {
     this.selectedPokemon = null;
   }
 
+  onNavigate(pokemonId: number) {
+    // Check if the Pokemon is in favorites
+    if (this.favoritesService.isFavorite(pokemonId)) {
+      // If it's in favorites, find it in the loaded favorites
+      const pokemon = this.favoritePokemon.find((p) => p.id === pokemonId);
+      if (pokemon) {
+        this.selectedPokemon = pokemon;
+      } else {
+        // If not loaded yet, fetch it
+        this.pokemonService.getPokemonWithGeneration(pokemonId).subscribe(
+          (pokemon) => {
+            this.selectedPokemon = pokemon;
+          },
+          (error) => {
+            console.error(`Error loading Pokemon #${pokemonId}:`, error);
+          }
+        );
+      }
+    } else {
+      // If not in favorites, fetch it but don't add to favorites list
+      this.pokemonService.getPokemonWithGeneration(pokemonId).subscribe(
+        (pokemon) => {
+          this.selectedPokemon = pokemon;
+        },
+        (error) => {
+          console.error(`Error loading Pokemon #${pokemonId}:`, error);
+        }
+      );
+    }
+  }
+
   goHome() {
     this.router.navigate(['/']);
   }

--- a/poKeAngular/src/app/pages/home/home.component.html
+++ b/poKeAngular/src/app/pages/home/home.component.html
@@ -28,5 +28,5 @@
 </main>
 
 <app-pokemon-modal *ngIf="showModal && selectedPokemon" [pokemon]="selectedPokemon" [isShiny]="isShinyMode"
-  (close)="onModalClose()">
+  (close)="onModalClose()" (navigate)="onNavigate($event)">
 </app-pokemon-modal>

--- a/poKeAngular/src/app/pages/home/home.component.ts
+++ b/poKeAngular/src/app/pages/home/home.component.ts
@@ -59,7 +59,7 @@ export class HomeComponent implements OnInit {
     'generation-viii': { start: 810, end: 905 },
     'generation-ix': { start: 906, end: 1010 },
   };
-  loadedGenerations = new Set<string>(['generation-i', 'generation-ii']);
+  loadedGenerations = new Set<string>(['generation-i', 'generation-ix']);
 
   constructor(private pokemonService: PokemonService) {}
 
@@ -177,5 +177,22 @@ export class HomeComponent implements OnInit {
   onModalClose() {
     this.showModal = false;
     this.selectedPokemon = null;
+  }
+
+  onNavigate(pokemonId: number) {
+    const pokemon = this.pokemon.find((p) => p.id === pokemonId);
+    if (pokemon) {
+      this.selectedPokemon = pokemon;
+    } else {
+      // If the Pokemon isn't loaded yet, fetch it
+      this.pokemonService.getPokemonWithGeneration(pokemonId).subscribe(
+        (pokemon) => {
+          this.selectedPokemon = pokemon;
+        },
+        (error) => {
+          console.error(`Error loading Pokemon #${pokemonId}:`, error);
+        }
+      );
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces functionality to navigate to specific Pokémon details from both the Favorites and Home components. It also updates the loaded generations in the Home component to include Generation IX. The most important changes are grouped into new feature additions and updates to existing functionality.

### New Feature Additions:

* [`poKeAngular/src/app/pages/favorites/favorites.component.ts`](diffhunk://#diff-ce842765588d191174a0be9e6c8c2d5325e08a4297ebc86fe22d1058e849ff60R103-R133): Added the `onNavigate` method to handle navigation to a Pokémon's details, checking if the Pokémon is in favorites and fetching data if not already loaded.
* [`poKeAngular/src/app/pages/home/home.component.ts`](diffhunk://#diff-bfaf8f82b0eb581d60c12b08c99d51eebd043e0434e9b28ea7aa313f1bd5fe6fR181-R197): Added the `onNavigate` method to handle navigation to a Pokémon's details, fetching data if the Pokémon is not already loaded.
* [`poKeAngular/src/app/pages/home/home.component.html`](diffhunk://#diff-29519309279e6311a53dddd51b5707fa696e6450cdc9380ee93699ccb2248660L31-R31): Updated the `<app-pokemon-modal>` component to emit a `navigate` event for handling Pokémon navigation.

### Updates to Existing Functionality:

* [`poKeAngular/src/app/pages/home/home.component.ts`](diffhunk://#diff-bfaf8f82b0eb581d60c12b08c99d51eebd043e0434e9b28ea7aa313f1bd5fe6fL62-R62): Changed the `loadedGenerations` initialization to include Generation IX, ensuring Pokémon from the latest generation are loaded.