### PR TITLE
fix carrusel issue

### DIFF
--- a/poKeAngular/src/app/components/pokemon-modal/pokemon-modal.component.html
+++ b/poKeAngular/src/app/components/pokemon-modal/pokemon-modal.component.html
@@ -39,16 +39,20 @@
         </div>
 
         <div class="modal-navigation">
-            <button class="nav-btn" (click)="onPrevious()" [disabled]="pokemon.id <= 1">
+            <button class="nav-btn" (click)="onPrevious()" [disabled]="!canNavigatePrevious">
                 ← Anterior
             </button>
-            <button class="nav-btn" (click)="onNext()">
+            <button class="nav-btn" (click)="onNext()" [disabled]="!canNavigateNext">
                 Siguiente →
             </button>
 
             <button class="nav-btn" (click)="toggleModel()">
                 {{ isModelVisible ? 'Ver Imagen' : 'Ver Modelo' }}
             </button>
+        </div>
+
+        <div class="navigation-info" *ngIf="filteredPokemon.length > 0">
+            <small>{{ currentIndex + 1 }} de {{ filteredPokemon.length }}</small>
         </div>
     </div>
 </div>

--- a/poKeAngular/src/app/pages/favorites/favorites.component.html
+++ b/poKeAngular/src/app/pages/favorites/favorites.component.html
@@ -36,5 +36,5 @@
 </main>
 
 <app-pokemon-modal *ngIf="showModal && selectedPokemon" [pokemon]="selectedPokemon" [isShiny]="isShinyMode"
-  (close)="onModalClose()">
+  [filteredPokemon]="filteredPokemon" (close)="onModalClose()" (navigate)="onNavigate($event)">
 </app-pokemon-modal>

--- a/poKeAngular/src/app/pages/favorites/favorites.component.ts
+++ b/poKeAngular/src/app/pages/favorites/favorites.component.ts
@@ -100,35 +100,8 @@ export class FavoritesComponent implements OnInit {
     this.selectedPokemon = null;
   }
 
-  onNavigate(pokemonId: number) {
-    // Check if the Pokemon is in favorites
-    if (this.favoritesService.isFavorite(pokemonId)) {
-      // If it's in favorites, find it in the loaded favorites
-      const pokemon = this.favoritePokemon.find((p) => p.id === pokemonId);
-      if (pokemon) {
-        this.selectedPokemon = pokemon;
-      } else {
-        // If not loaded yet, fetch it
-        this.pokemonService.getPokemonWithGeneration(pokemonId).subscribe(
-          (pokemon) => {
-            this.selectedPokemon = pokemon;
-          },
-          (error) => {
-            console.error(`Error loading Pokemon #${pokemonId}:`, error);
-          }
-        );
-      }
-    } else {
-      // If not in favorites, fetch it but don't add to favorites list
-      this.pokemonService.getPokemonWithGeneration(pokemonId).subscribe(
-        (pokemon) => {
-          this.selectedPokemon = pokemon;
-        },
-        (error) => {
-          console.error(`Error loading Pokemon #${pokemonId}:`, error);
-        }
-      );
-    }
+  onNavigate(pokemon: Pokemon) {
+    this.selectedPokemon = pokemon;
   }
 
   goHome() {

--- a/poKeAngular/src/app/pages/home/home.component.html
+++ b/poKeAngular/src/app/pages/home/home.component.html
@@ -28,5 +28,5 @@
 </main>
 
 <app-pokemon-modal *ngIf="showModal && selectedPokemon" [pokemon]="selectedPokemon" [isShiny]="isShinyMode"
-  (close)="onModalClose()" (navigate)="onNavigate($event)">
+  [filteredPokemon]="filteredPokemon" (close)="onModalClose()" (navigate)="onNavigate($event)">
 </app-pokemon-modal>

--- a/poKeAngular/src/app/pages/home/home.component.ts
+++ b/poKeAngular/src/app/pages/home/home.component.ts
@@ -179,20 +179,7 @@ export class HomeComponent implements OnInit {
     this.selectedPokemon = null;
   }
 
-  onNavigate(pokemonId: number) {
-    const pokemon = this.pokemon.find((p) => p.id === pokemonId);
-    if (pokemon) {
-      this.selectedPokemon = pokemon;
-    } else {
-      // If the Pokemon isn't loaded yet, fetch it
-      this.pokemonService.getPokemonWithGeneration(pokemonId).subscribe(
-        (pokemon) => {
-          this.selectedPokemon = pokemon;
-        },
-        (error) => {
-          console.error(`Error loading Pokemon #${pokemonId}:`, error);
-        }
-      );
-    }
+  onNavigate(pokemon: Pokemon) {
+    this.selectedPokemon = pokemon;
   }
 }


### PR DESCRIPTION
This pull request refactors the navigation logic in the Pokémon modal component and updates the interaction between the modal and its parent components. The changes improve navigation by introducing a filtered list of Pokémon and enhance code readability and maintainability by simplifying event handling and adding lifecycle hooks.

### Navigation Improvements:
* [`poKeAngular/src/app/components/pokemon-modal/pokemon-modal.component.html`](diffhunk://#diff-0b903f091f3689aa6de9825b35d9ed53ac2bf33cffd5e7bdde495666dfe202fbL42-R56): Updated navigation buttons to use new computed properties (`canNavigatePrevious` and `canNavigateNext`) for enabling/disabling navigation. Added a navigation info section to display the current Pokémon index out of the filtered list.
* [`poKeAngular/src/app/components/pokemon-modal/pokemon-modal.component.ts`](diffhunk://#diff-d02c832ec19740c9956971c695560f50c7c7600ea6f23e51b7c0cfc0d2544a9eL21-R62): Introduced `filteredPokemon` and `currentIndex` properties to manage navigation within a filtered list. Added lifecycle hooks (`OnChanges`) to update navigation state when inputs change. Refactored `onPrevious` and `onNext` methods to use the filtered list for navigation. [[1]](diffhunk://#diff-d02c832ec19740c9956971c695560f50c7c7600ea6f23e51b7c0cfc0d2544a9eL21-R62) [[2]](diffhunk://#diff-d02c832ec19740c9956971c695560f50c7c7600ea6f23e51b7c0cfc0d2544a9eR110-R117) [[3]](diffhunk://#diff-d02c832ec19740c9956971c695560f50c7c7600ea6f23e51b7c0cfc0d2544a9eL107-R147)

### Integration with Parent Components:
* [`poKeAngular/src/app/pages/favorites/favorites.component.html`](diffhunk://#diff-ec6a8775fce0edf50ffc514888a53bb4694df338e4d5a618f28df1ce1be802ffL39-R39): Passed the `filteredPokemon` list to the modal and updated the `navigate` event to handle Pokémon objects instead of IDs.
* [`poKeAngular/src/app/pages/favorites/favorites.component.ts`](diffhunk://#diff-ce842765588d191174a0be9e6c8c2d5325e08a4297ebc86fe22d1058e849ff60L103-L131): Simplified `onNavigate` logic to directly update the selected Pokémon without additional fetching.
* [`poKeAngular/src/app/pages/home/home.component.html`](diffhunk://#diff-29519309279e6311a53dddd51b5707fa696e6450cdc9380ee93699ccb2248660L31-R31): Similar updates to pass `filteredPokemon` and handle navigation events in the home component.
* [`poKeAngular/src/app/pages/home/home.component.ts`](diffhunk://#diff-bfaf8f82b0eb581d60c12b08c99d51eebd043e0434e9b28ea7aa313f1bd5fe6fL182-L196): Simplified `onNavigate` logic to directly update the selected Pokémon.